### PR TITLE
Disable scroll zoom for the map

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,8 @@
         L.marker([45, 5]).addTo(mymap);
         L.marker([43, 1]).addTo(mymap);
         L.marker([47, 3]).addTo(mymap);
-
+        
+        mymap.scrollZoom.disable();
       </script>
 
   </body>


### PR DESCRIPTION
I propose to remove the scroll zoom for the map at the bottom of the front page. 
If the scroll zoom is active, when you scroll down the page, it zoom out the map (which can be annoying).